### PR TITLE
$ViewMapDataset seqnum should be unsigned and added some getters

### DIFF
--- a/domino-jnx-api/src/main/java/com/hcl/domino/richtext/records/ViewmapDatasetRecord.java
+++ b/domino-jnx-api/src/main/java/com/hcl/domino/richtext/records/ViewmapDatasetRecord.java
@@ -44,7 +44,7 @@ import com.hcl.domino.richtext.structures.WSIG;
     @StructureMember(name = "bAutoAdjust", type = short.class, unsigned = true),
     @StructureMember(name = "BGColor", type = short.class, unsigned = true),
     /* highest sequence number for each type of draw object supported (w/extra space for future) */
-    @StructureMember(name = "SeqNums", type = short[].class, length = ViewmapDatasetRecord.VM_MAX_OBJTYPES),
+    @StructureMember(name = "SeqNums", type = short[].class, length = ViewmapDatasetRecord.VM_MAX_OBJTYPES, unsigned = true),
     @StructureMember(name = "StyleDefaults", type = ViewmapStyleDefaults.class),
     @StructureMember(name = "NumPaletteEntries", type = short.class, unsigned = true),
     @StructureMember(name = "ViewDesignType", type = short.class, unsigned = true), /* design type of initial view */
@@ -92,6 +92,18 @@ public interface ViewmapDatasetRecord extends RichTextRecord<WSIG> {
 
   @StructureGetter("Flags")
   Set<Flags> getFlags();
+
+  @StructureGetter("bAutoAdjust")
+  int getbAutoAdjust();
+
+  @StructureGetter("BGColor")
+  int getBGColor();
+
+  @StructureGetter("SeqNums")
+  int[] getSeqNums();
+
+  @StructureGetter("StyleDefaults")
+  ViewmapStyleDefaults getStyleDefaults();
 
   @StructureGetter("NumPaletteEntries")
   int getNumPaletteEntries();

--- a/domino-jnx-api/src/main/java/com/hcl/domino/richtext/records/ViewmapLineDefaults.java
+++ b/domino-jnx-api/src/main/java/com/hcl/domino/richtext/records/ViewmapLineDefaults.java
@@ -20,7 +20,6 @@ import com.hcl.domino.richtext.annotation.StructureDefinition;
 import com.hcl.domino.richtext.annotation.StructureGetter;
 import com.hcl.domino.richtext.annotation.StructureMember;
 import com.hcl.domino.richtext.annotation.StructureSetter;
-import com.hcl.domino.richtext.structures.FontStyle;
 import com.hcl.domino.richtext.structures.MemoryStructure;
 
 /**
@@ -37,8 +36,7 @@ import com.hcl.domino.richtext.structures.MemoryStructure;
     @StructureMember(name = "FillBGColor", type = short.class, unsigned = true),
     @StructureMember(name = "LineStyle", type = short.class, unsigned = true),
     @StructureMember(name = "LineWidth", type = short.class, unsigned = true),
-    @StructureMember(name = "FillStyle", type = short.class, unsigned = true),
-    @StructureMember(name = "FontID", type = FontStyle.class)
+    @StructureMember(name = "FillStyle", type = short.class, unsigned = true)
   }
 )
 public interface ViewmapLineDefaults extends MemoryStructure {
@@ -62,9 +60,6 @@ public interface ViewmapLineDefaults extends MemoryStructure {
 
   @StructureGetter("FillStyle")
   int getFillStyle();
-
-  @StructureGetter("FontID")
-  FontStyle getFontID();
 
   @StructureSetter("LineColor")
   ViewmapLineDefaults setbHighlightTouch(int lineColor);


### PR DESCRIPTION
Fixes for @ViewMapDataset:
* change seqNums to unsigned
* added a few missing getters
* removed fontid from line defaults (was not supposed to be there, cut/paste error)

Result:
1. all ViewMapDataset attributes are included now
2. but, i get like 19 extra bytes that I'm not expecting. they show up in notespeek, but i don't know how they show up in the json (must be some CD record that was already defined?)
3. i still need to check ViewMapLayout



```javascript
[
  {
    "viewMapDataset": [
      {
        "gridsize": 0,
        "spare": [
          0,
          0,
          0,
          0,
          0,
          0,
          0,
          0,
          0,
          0,
          0,
          0,
          0,
          0
        ],
        "numPaletteEntries": 7,
        "viewNameLen": 6,
        "flags": [],
        "bAutoAdjust": 0,
        "viewDesignType": 0,
        "seqNums": [
          0,
          0,
          0,
          0,
          0,
          0,
          5,
          1,
          5,
          0,
          0,
          0,
          0,
          0,
          0,
          0,
          0,
          0,
          0,
          0,
          0,
          0,
          0,
          0,
          0,
          0,
          0,
          0,
          0,
          0,
          0,
          0
        ],
        "type": [
          "VMDATASET"
        ],
        "header": {
          "signature": -169,
          "length": 297
        },
        "version": 9,
        "bgcolor": 1,
        "bgcolorValue": {
          "blue": 255,
          "flags": [
            "ISRGB"
          ],
          "red": 255,
          "green": 255,
          "component4": 0
        },
        "styleDefaults": {
          "shapes": {
            "fillFGColor": 7,
            "lineStyle": 0,
            "lineWidth": 1,
            "highlight": {
              "bHighlightTouch": 0,
              "hloutlineColor": 2,
              "hlfillColor": 65535,
              "bHighlightCurrent": 0,
              "hloutlineWidth": 2,
              "hloutlineStyle": 0
            },
            "fillBGColor": 7,
            "lineColor": 0,
            "fillStyle": 1,
            "fontID": {
              "sub": false,
              "color": "Black",
              "shadow": false,
              "super": false,
              "attributes": [],
              "extrude": false,
              "underline": false,
              "colorRaw": 0,
              "standardFont": "SWISS",
              "italic": false,
              "bold": false,
              "strikeout": false,
              "pointSize": 10,
              "fontFace": 1
            }
          },
          "buttons": {
            "fillFGColor": 15,
            "lineStyle": 0,
            "lineWidth": 1,
            "highlight": {
              "bHighlightTouch": 0,
              "hloutlineColor": 2,
              "hlfillColor": 65535,
              "bHighlightCurrent": 0,
              "hloutlineWidth": 2,
              "hloutlineStyle": 0
            },
            "fillBGColor": 15,
            "lineColor": 207,
            "fillStyle": 1,
            "fontID": {
              "sub": false,
              "color": "Black",
              "shadow": false,
              "super": false,
              "attributes": [],
              "extrude": false,
              "underline": false,
              "colorRaw": 0,
              "standardFont": "SWISS",
              "italic": false,
              "bold": false,
              "strikeout": false,
              "pointSize": 10,
              "fontFace": 1
            }
          },
          "lines": {
            "fillFGColor": 0,
            "lineStyle": 0,
            "lineWidth": 1,
            "highlight": {
              "bHighlightTouch": 0,
              "hloutlineColor": 2,
              "hlfillColor": 65535,
              "bHighlightCurrent": 0,
              "hloutlineWidth": 2,
              "hloutlineStyle": 0
            },
            "fillBGColor": 0,
            "lineColor": 0,
            "fillStyle": 0
          },
          "regions": {
            "highlight": {
              "bHighlightTouch": 0,
              "hloutlineColor": 2,
              "hlfillColor": 65535,
              "bHighlightCurrent": 0,
              "hloutlineWidth": 2,
              "hloutlineStyle": 0
            }
          },
          "bitmaps": {
            "highlight": {
              "bHighlightTouch": 0,
              "hloutlineColor": 2,
              "hlfillColor": 65535,
              "bHighlightCurrent": 0,
              "hloutlineWidth": 2,
              "hloutlineStyle": 0
            }
          },
          "textBoxes": {
            "fillFGColor": 1,
            "lineStyle": 5,
            "lineWidth": 1,
            "highlight": {
              "bHighlightTouch": 0,
              "hloutlineColor": 2,
              "hlfillColor": 65535,
              "bHighlightCurrent": 0,
              "hloutlineWidth": 2,
              "hloutlineStyle": 0
            },
            "fillBGColor": 1,
            "lineColor": 0,
            "fillStyle": 0,
            "fontID": {
              "sub": false,
              "color": "Black",
              "shadow": false,
              "super": false,
              "attributes": [],
              "extrude": false,
              "underline": false,
              "colorRaw": 0,
              "standardFont": "SWISS",
              "italic": false,
              "bold": false,
              "strikeout": false,
              "pointSize": 10,
              "fontFace": 1
            }
          }
        }
      }
    ],
    "viewMapLayout": [
      {
        "header": {
          "signature": -81,
          "length": 6
        },
        "type": [
          "VMHEADER"
        ]
      },
      {
        "header": {
          "signature": -69,
          "length": 101
        },
        "type": [
          "PABHIDE",
          "VMTEXTBOX"
        ]
      },
      {
        "header": {
          "signature": -69,
          "length": 97
        },
        "type": [
          "PABHIDE",
          "VMTEXTBOX"
        ]
      },
      {
        "header": {
          "signature": -69,
          "length": 109
        },
        "type": [
          "PABHIDE",
          "VMTEXTBOX"
        ]
      },
      {
        "header": {
          "signature": -69,
          "length": 104
        },
        "type": [
          "PABHIDE",
          "VMTEXTBOX"
        ]
      },
      {
        "header": {
          "signature": -69,
          "length": 95
        },
        "type": [
          "PABHIDE",
          "VMTEXTBOX"
        ]
      },
      {
        "header": {
          "signature": -76,
          "length": 81
        },
        "type": [
          "VMREGION"
        ]
      },
      {
        "header": {
          "signature": -70,
          "length": 78
        },
        "type": [
          "VMACTION_2"
        ]
      },
      {
        "header": {
          "signature": -76,
          "length": 82
        },
        "type": [
          "VMREGION"
        ]
      },
      {
        "header": {
          "signature": -70,
          "length": 81
        },
        "type": [
          "VMACTION_2"
        ]
      },
      {
        "header": {
          "signature": -76,
          "length": 82
        },
        "type": [
          "VMREGION"
        ]
      },
      {
        "header": {
          "signature": -70,
          "length": 85
        },
        "type": [
          "VMACTION_2"
        ]
      },
      {
        "header": {
          "signature": -76,
          "length": 83
        },
        "type": [
          "VMREGION"
        ]
      },
      {
        "header": {
          "signature": -70,
          "length": 93
        },
        "type": [
          "VMACTION_2"
        ]
      },
      {
        "header": {
          "signature": -80,
          "length": 74
        },
        "type": [
          "VMBITMAP"
        ]
      },
      {
        "header": {
          "signature": 149,
          "length": 38
        },
        "type": [
          "BITMAPHEADER"
        ]
      },
      {
        "header": {
          "signature": 150,
          "length": 546
        },
        "type": [
          "BITMAPSEGMENT"
        ]
      },
      {
        "header": {
          "signature": 150,
          "length": 715
        },
        "type": [
          "BITMAPSEGMENT"
        ]
      },
      {
        "header": {
          "signature": 150,
          "length": 982
        },
        "type": [
          "BITMAPSEGMENT"
        ]
      },
      {
        "header": {
          "signature": 150,
          "length": 970
        },
        "type": [
          "BITMAPSEGMENT"
        ]
      },
      {
        "header": {
          "signature": 150,
          "length": 350
        },
        "type": [
          "BITMAPSEGMENT"
        ]
      },
      {
        "header": {
          "signature": 150,
          "length": 769
        },
        "type": [
          "BITMAPSEGMENT"
        ]
      },
      {
        "header": {
          "signature": 150,
          "length": 66
        },
        "type": [
          "BITMAPSEGMENT"
        ]
      },
      {
        "header": {
          "signature": 151,
          "length": 774
        },
        "type": [
          "COLORTABLE"
        ]
      },
      {
        "header": {
          "signature": 152,
          "length": 294
        },
        "type": [
          "PATTERNTABLE"
        ]
      }
    ],
    "aliases": [],
    "title": "Main Navigator",
    "document": {
      "unid": "D759A69EE30036E785256207004F6B12"
    },
    "comment": "",
    "designerVersion": "",
    "hideFromMobile": false,
    "hideFromNotes": false,
    "hideFromWeb": true,
    "prohibitRefresh": false,
    "allowPublicAccess": false,
    "flags": "G3w",
    "flagsExt": "",
    "webFlags": ""
  }
]
```