### PR TITLE
added missing flag constants for odsbigobj and odsdrobj

### DIFF
--- a/domino-jnx-api/src/main/java/com/hcl/domino/richtext/records/VMODSbigobj.java
+++ b/domino-jnx-api/src/main/java/com/hcl/domino/richtext/records/VMODSbigobj.java
@@ -16,6 +16,10 @@
  */
 package com.hcl.domino.richtext.records;
 
+import java.util.Optional;
+
+import com.hcl.domino.data.StandardColors;
+import com.hcl.domino.misc.DominoEnumUtil;
 import com.hcl.domino.misc.INumberEnum;
 import com.hcl.domino.richtext.annotation.StructureDefinition;
 import com.hcl.domino.richtext.annotation.StructureGetter;
@@ -48,7 +52,10 @@ import com.hcl.domino.richtext.structures.WSIG;
 public interface VMODSbigobj extends RichTextRecord<WSIG> {
 
   enum Flags implements INumberEnum<Short> {
-    /* no ENUM values defined in doc or .h file */
+    VISIBLE((short)0x0002), /*	Set if obj is visible */
+    SELECTABLE((short)0x0004), /*	Set if obj can be select (i.e. is not background) */
+    LOCKED((short)0x0008), /*	Set if obj can't be edited */
+    IMAGEMAP_BITMAP((short)0x0010) /*	Bitmap representing runtime image of the navigator.  Use to create imagemaps from navigators. */
     ;
 
     private final short value;
@@ -84,7 +91,11 @@ public interface VMODSbigobj extends RichTextRecord<WSIG> {
   FontStyle getFontID();
 
   @StructureGetter("TextColor")
-  int getTextColor();
+  int getTextColorRaw();
+
+  default Optional<StandardColors> getTextColor() {
+    return DominoEnumUtil.valueOf(StandardColors.class, getTextColorRaw());
+  }
 
   @StructureGetter("Alignment")
   int getAlignment();
@@ -102,7 +113,11 @@ public interface VMODSbigobj extends RichTextRecord<WSIG> {
   VMODSbigobj setLabelLen(int length);
 
   @StructureSetter("TextColor")
-  VMODSbigobj setTextColor(int color);
+  VMODSbigobj setTextColorRaw(int color);
+
+  default VMODSbigobj setTextColor(StandardColors color) {
+	  return setTextColorRaw(color.getValue());
+  }
 
   @StructureSetter("Alignment")
   VMODSbigobj setAlignment(int alignment);

--- a/domino-jnx-api/src/main/java/com/hcl/domino/richtext/records/VMODSdrobj.java
+++ b/domino-jnx-api/src/main/java/com/hcl/domino/richtext/records/VMODSdrobj.java
@@ -16,6 +16,10 @@
  */
 package com.hcl.domino.richtext.records;
 
+import java.util.Optional;
+
+import com.hcl.domino.data.StandardColors;
+import com.hcl.domino.misc.DominoEnumUtil;
 import com.hcl.domino.misc.INumberEnum;
 import com.hcl.domino.richtext.annotation.StructureDefinition;
 import com.hcl.domino.richtext.annotation.StructureGetter;
@@ -48,7 +52,10 @@ import com.hcl.domino.richtext.structures.BSIG;
 public interface VMODSdrobj extends RichTextRecord<BSIG> {
 
   enum Flags implements INumberEnum<Short> {
-    /* no ENUM values defined in doc or .h file */
+    VISIBLE((short)0x0002), /*	Set if obj is visible */
+    SELECTABLE((short)0x0004), /*	Set if obj can be select (i.e. is not background) */
+    LOCKED((short)0x0008), /*	Set if obj can't be edited */
+    IMAGEMAP_BITMAP((short)0x0010) /*	Bitmap representing runtime image of the navigator.  Use to create imagemaps from navigators. */
     ;
 
     private final short value;
@@ -84,7 +91,11 @@ public interface VMODSdrobj extends RichTextRecord<BSIG> {
   FontStyle getFontID();
 
   @StructureGetter("TextColor")
-  int getTextColor();
+  int getTextColorRaw();
+
+  default Optional<StandardColors> getTextColor() {
+    return DominoEnumUtil.valueOf(StandardColors.class, getTextColorRaw());
+  }
 
   @StructureGetter("Alignment")
   int getAlignment();
@@ -102,7 +113,11 @@ public interface VMODSdrobj extends RichTextRecord<BSIG> {
   VMODSdrobj setLabelLen(int length);
 
   @StructureSetter("TextColor")
-  VMODSdrobj setTextColor(int color);
+  VMODSdrobj setTextColorRaw(int color);
+
+  default VMODSdrobj setTextColor(StandardColors color) {
+	  return setTextColorRaw(color.getValue());
+  }
 
   @StructureSetter("Alignment")
   VMODSdrobj setAlignment(int alignment);


### PR DESCRIPTION
I just noticed this missing. Tests haven't been written yet, but this will be needed for testing later. Also threw in the "raw" getter/setter for the textcolor attribute.