### PR TITLE
Added the flattenBlankStringList option to the JsonSerializer

### DIFF
--- a/domino-jnx-api/src/main/java/com/hcl/domino/json/JsonSerializer.java
+++ b/domino-jnx-api/src/main/java/com/hcl/domino/json/JsonSerializer.java
@@ -255,6 +255,20 @@ public interface JsonSerializer {
   JsonSerializer metaOnly(boolean metaOnly);
 
   /**
+   * Sets whether or not the serializer will flatten lists that contain only one blank string ([""]).
+   * <p>
+   * When {@code flattenBlankStringList} is set to {@code true}, a list with one blank string
+   * is transformed into an empty JSON array ([]). If set to {@code false} (the default),
+   * the output remains a JSON array containing a single blank string ([""]).
+   *
+   * @param flattenBlankStringList {@code true} to treat a single blank string list as an empty array,
+   *                               {@code false} to preserve it as [""].
+   * @return this serializer
+   * @since 1.45.0
+   */
+  JsonSerializer flattenBlankStringList(boolean flattenBlankStringList);
+
+  /**
    * Serializes the provided document as a JSON object using the implementation's
    * native JSON type.
    *

--- a/domino-jnx-commons/src/main/java/com/hcl/domino/commons/json/AbstractJsonSerializer.java
+++ b/domino-jnx-commons/src/main/java/com/hcl/domino/commons/json/AbstractJsonSerializer.java
@@ -42,6 +42,7 @@ public abstract class AbstractJsonSerializer implements JsonSerializer {
   protected boolean lowercaseProperties;
   protected boolean includeMetadata;
   protected boolean metaOnly;
+  protected boolean flattenBlankStringList;
 
   protected Collection<String> booleanItemNames = Collections.emptySet();
 
@@ -147,6 +148,12 @@ public abstract class AbstractJsonSerializer implements JsonSerializer {
   @Override
   public JsonSerializer metaOnly(boolean metaOnly) {
     this.metaOnly = metaOnly;
+    return this;
+  }
+
+  @Override
+  public JsonSerializer flattenBlankStringList(boolean flattenBlankStringList) {
+    this.flattenBlankStringList = flattenBlankStringList;
     return this;
   }
 

--- a/integration/domino-jnx-jsonb/src/main/java/com/hcl/domino/jnx/jsonb/service/JsonbSerializer.java
+++ b/integration/domino-jnx-jsonb/src/main/java/com/hcl/domino/jnx/jsonb/service/JsonbSerializer.java
@@ -56,6 +56,7 @@ public class JsonbSerializer extends AbstractJsonSerializer {
                       .richTextHtmlOptions(this.htmlConvertOptions)
                       .customProcessors(this.customProcessors)
                       .metaOnly(this.metaOnly)
+                      .flattenBlankStringList(this.flattenBlankStringList)
                       .build(),
                   DominoDateTimeSerializer.INSTANCE,
                   DominoDateRangeSerializer.INSTANCE

--- a/integration/domino-jnx-vertx-json/src/main/java/com/hcl/domino/jnx/vertx/json/service/VertxJsonSerializer.java
+++ b/integration/domino-jnx-vertx-json/src/main/java/com/hcl/domino/jnx/vertx/json/service/VertxJsonSerializer.java
@@ -252,7 +252,13 @@ public class VertxJsonSerializer extends AbstractJsonSerializer {
                   result.put(propName, false);
                 }
               } else {
-                result.put(propName, vals);
+                boolean flatten = vals.size() == 1 && vals.get(0).isEmpty() && this.flattenBlankStringList;
+
+                if (flatten) {
+                  result.put(propName, Collections.emptyList());
+                } else {
+                  result.put(propName, vals);
+                }
               }
               break;
             }


### PR DESCRIPTION
This pull request addresses enhancement request #447.

In the current implementation, a text list field with no value is represented as a list containing a single blank string ([””]). When serialized to JSON, this results in a JSON array with one blank string ([””]). However, in standard JSON conventions, an empty list is typically represented as an empty array ([]).

The new flattenBlankStringList option has been introduced to address this behavior.

By default, this option is set to false, preserving the existing behavior to avoid introducing a breaking change. When set to true, a text list containing only a single blank string will instead serialize as an empty array ([]).

This approach allows developers to control how blank string lists are serialized while maintaining backward compatibility by default.