### PR TITLE
DesignOnly flag implemented, encryption option is fixed.

### DIFF
--- a/domino-jnx-api/src/main/java/com/hcl/domino/DominoClient.java
+++ b/domino-jnx-api/src/main/java/com/hcl/domino/DominoClient.java
@@ -471,6 +471,30 @@ public interface DominoClient extends IAdaptable, AutoCloseable {
       Encryption encryption);
 
   /**
+   * Creates a new database from the specified template DB. Handles copying all
+   * design/data
+   * documents,
+   * setting the inherited template name and creating a ACL based on ACL entries
+   * of the template,
+   * e.g. a "[Group1]" entry of the template becomes a "Group1" entry in the
+   * created DB.
+   *
+   * @param sourceServerName server name of template database
+   * @param sourceFilePath   filepath of template database
+   * @param targetServerName Domino server name to connect to, or an empty string
+   *                         for the current
+   *                         server
+   * @param targetFilePath   the file path of the destination database
+   * @param encryption       encryption level for new database
+   * @param designOnly       if true, only design documents will be copied from
+   *                         the template; if false, both
+   * @return a database object for the newly-created database
+   */
+  Database createDatabaseFromTemplate(String sourceServerName, String sourceFilePath,
+      String targetServerName, String targetFilePath,
+      Encryption encryption, boolean designOnly);
+
+  /**
    * Creates a new database replica, which is a new database with copied
    * design/data documents
    * and the same replica ID as the specified DB.

--- a/domino-jnx-jna/src/main/java/com/hcl/domino/jna/JNADominoClient.java
+++ b/domino-jnx-jna/src/main/java/com/hcl/domino/jna/JNADominoClient.java
@@ -500,6 +500,14 @@ public class JNADominoClient implements IGCDominoClient<JNADominoClientAllocatio
   public Database createDatabaseFromTemplate(String sourceServerName, String sourceFilePath,
       String targetServerName, String targetFilePath,
       Encryption encryption) {
+    return createDatabaseFromTemplate(sourceServerName, sourceFilePath, targetServerName,
+        targetFilePath, encryption, false);
+  }
+
+  @Override
+  public Database createDatabaseFromTemplate(String sourceServerName, String sourceFilePath,
+      String targetServerName, String targetFilePath,
+      Encryption encryption, boolean designOnly) {
 
     EnumSet<CopyDatabase> copyFlags = EnumSet.noneOf(CopyDatabase.class);
     if (encryption == Encryption.Simple) {
@@ -510,10 +518,15 @@ public class JNADominoClient implements IGCDominoClient<JNADominoClientAllocatio
       copyFlags.add(CopyDatabase.ENCRYPT_STRONG);
     }
 
-    Database newDb = createAndCopyDatabase(sourceServerName, sourceFilePath, targetServerName,
-        targetFilePath, null, 0,
-        (Set<CopyDatabase>) null, null);
-    return newDb;
+    Set<DocumentClass> docClassesToCopy = null; // By default, all document classes.
+
+    if(designOnly) {
+      // Only non-data ones
+      docClassesToCopy = EnumSet.of(DocumentClass.ALLNONDATA);
+    }
+
+    return createAndCopyDatabase(sourceServerName, sourceFilePath, targetServerName,
+        targetFilePath, docClassesToCopy, 0, copyFlags, null);
   }
 
   @Override

--- a/test/it-domino-jnx/src/test/java/it/com/hcl/domino/test/data/TestDatabase.java
+++ b/test/it-domino-jnx/src/test/java/it/com/hcl/domino/test/data/TestDatabase.java
@@ -103,6 +103,7 @@ public class TestDatabase extends AbstractNotesRuntimeTest {
     final Database database = client.createDatabaseFromTemplate(sourceServerName, sourceFilePath,
         null, tempDest.toString(), Encryption.None);
     Assertions.assertNotNull(database);
+    Assertions.assertFalse(database.isLocallyEncrypted());
 
     try {
       Assertions.assertNotEquals(templateDbReplicaId, database.getReplicaID());
@@ -122,6 +123,51 @@ public class TestDatabase extends AbstractNotesRuntimeTest {
     } finally {
       database.close();
       client.deleteDatabase(null, tempDest.toString());
+    }
+  }
+
+  @Test
+  public void testCreateDbFromTemplateDesignOnly() throws IOException {
+    final DominoClient client = this.getClient();
+
+    final Path fullCopyDbPath = Files.createTempFile("fullCopy", ".nsf");
+    Files.delete(fullCopyDbPath);
+
+    final Path designOnlyDbPath = Files.createTempFile("designOnly", ".nsf");
+    Files.delete(designOnlyDbPath);
+
+    final Database namesDb = client.openDatabase("", "names.nsf");
+
+    Database fullCopyDb = null;
+    Database designOnlyDb = null;
+
+    try {
+      long docCount = namesDb.queryDocuments().getDocuments().count();
+
+      namesDb.close();
+
+      fullCopyDb = client.createDatabaseFromTemplate("", "names.nsf",
+          "", fullCopyDbPath.toString(), Encryption.Medium, false);
+
+      Assertions.assertEquals(Encryption.Medium, fullCopyDb.getLocalEncryptionInfo().getStrength().orElse(null));
+      Assertions.assertEquals(docCount, fullCopyDb.queryDocuments().getDocuments().count());
+
+      designOnlyDb = client.createDatabaseFromTemplate("", "names.nsf",
+          "", designOnlyDbPath.toString(), Encryption.Strong, true);
+
+      Assertions.assertEquals(Encryption.Strong, designOnlyDb.getLocalEncryptionInfo().getStrength().orElse(null));
+      Assertions.assertEquals(0, designOnlyDb.queryDocuments().getDocuments().count());
+
+    } finally {
+      if(fullCopyDb!=null) {
+        fullCopyDb.close();
+        client.deleteDatabase(null, fullCopyDbPath.toString());
+      }
+
+      if(designOnlyDb!=null) {
+        designOnlyDb.close();
+        client.deleteDatabase(null, designOnlyDbPath.toString());
+      }
     }
   }
 


### PR DESCRIPTION
- Added designOnly flag as an overload for DominoClient.createDatabaseFromTemplate()
- Fixed encryption in the method: Previously, JNADatabase was ignoring encryption parameter.